### PR TITLE
fix a bug for zscore, when member not exist

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -206,6 +206,8 @@ func (c *Client) connHandler() {
 		} else if err != nil && err != io.EOF {
 			log.Error(err.Error())
 			return
+		} else if err != nil {
+			return
 		}
 		err = c.handleRequest(req)
 		if err != nil && err != io.EOF {

--- a/server/client.go
+++ b/server/client.go
@@ -321,15 +321,23 @@ func (c *Client) handleRequest(req [][]byte) error {
 	case "ping":
 		if len(c.args) != 0 {
 			c.FlushResp(terror.ErrCmdParams)
+		} else {
+			c.FlushResp("PONG")
 		}
-		c.FlushResp("PONG")
-
 		return nil
 	case "echo":
 		if len(c.args) != 1 {
 			c.FlushResp(terror.ErrCmdParams)
+		} else {
+			c.FlushResp(c.args[0])
 		}
-		c.FlushResp(c.args[0])
+		return nil
+	case "info":
+		if len(c.args) == 1 {
+			c.FlushResp([]byte("# Cluster\r\ncluster_enabled:0\r\n"))
+		} else {
+			c.FlushResp([]byte("# Server\r\nredis_mode:standalone\r\n"))
+		}
 		return nil
 	}
 

--- a/server/command_zset.go
+++ b/server/command_zset.go
@@ -390,14 +390,17 @@ func zscoreCommand(c *Client) error {
 		return terror.ErrCmdParams
 	}
 
-	v, err := c.tdb.Zscore(c.GetCurrentTxn(), c.args[0], c.args[1])
+	v, exist, err := c.tdb.Zscore(c.GetCurrentTxn(), c.args[0], c.args[1])
 	if err != nil {
 		return err
 	}
 
-	str := strconv.AppendInt([]byte(nil), v, 10)
-
-	return c.Resp(str)
+	if exist {
+		str := strconv.AppendInt([]byte(nil), v, 10)
+		return c.Resp(str)
+	} else {
+		return c.Resp([]byte(nil))
+	}
 }
 
 func zremCommand(c *Client) error {


### PR DESCRIPTION
when member not exist in zset, server should return (nil), not "0"